### PR TITLE
feat(preproc): add cva6-style synth-on/off pragmas

### DIFF
--- a/include/svase/preproc.h
+++ b/include/svase/preproc.h
@@ -34,8 +34,9 @@ public:
 
   // TODO: glibcxx has known overflow bugs... use an alternative?
   void filterPragmaTranslate(std::string &strBuf, BufferID &id) {
-    std::regex reOff(R"(//\s*pragma\s+translate[_ ]off)");
-    std::regex reOn(R"(//\s*pragma\s+translate[_ ]on)");
+    // match '// pragma translate on/off' and '// synthesis translate on/off'
+    std::regex reOff(R"(\/\/\s*(?:pragma|synthesis)\s+translate[_ ]off)");
+    std::regex reOn(R"(\/\/\s*(?:pragma|synthesis)\s+translate[_ ]on)");
     std::smatch match;
     // Overwrite these matches with whitespace of equal length
     auto start = strBuf.cbegin();


### PR DESCRIPTION
Add preprocessing of [cva6](https://github.com/pulp-platform/cva6)-style synthesis on/off pragmas, used to filter out blocks like this:
```sv
//pragma translate_off
initial begin
  assert (AxiNumWords >= 1) else
    $fatal(1, "[axi adapter] AxiNumWords must be >= 1");
  assert (AxiIdWidth >= 2) else
    $fatal(1, "[axi adapter] AXI id width must be at least 2 bit wide");
end
//pragma translate_on
```