### PR TITLE
Necessary fixes for Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         export GID=$(id -g)
         export REPO_PATH=${{github.workspace}}/
         export CMAKE_BUILD_PORTABLE=1
-        docker-compose -f .github/docker/docker-compose.yml up
+        docker compose -f .github/docker/docker-compose.yml up
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The following requirements should be sufficient:
 - C++20 compatible compiler (GCC 10, Clang 16, XCode 14.3)
 - Python 3
 
-The only tested configuration is GCC 11.2.0 with CMake 3.20.2 and Python 3.6.
+The tested configurations are:
+- GCC 11.2, CMake 3.20 and Python 3.6.
+- GCC 13.1, CMake 3.30 and Python 3.8.
 Depending on where/how you installed the compiler, CMake may not find the correct one. In this case you can manually specify a compiler, `scripts/svase.env` provides and example for this.
 
 #### Build

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -132,10 +132,11 @@ int driverMain(int argc, char **argv) {
   std::string slangArgs = cmdOptsRes.count("slang-args")
                               ? cmdOptsRes["slang-args"].as<std::string>()
                               : "";
-  auto slangCmd = fmt::format(
-      "{} {} {} --top {} {}", argv[0], slangArgs, builtinFlags,
-      cmdOptsRes["top"].as<std::string>(),
+  auto filesStr = fmt::to_string(
       fmt::join(cmdOptsRes["files"].as<std::vector<std::string>>(), " "));
+  auto slangCmd =
+      fmt::format("{} {} {} --top {} {}", argv[0], slangArgs, builtinFlags,
+                  cmdOptsRes["top"].as<std::string>(), filesStr);
   ok &= slangDriver.parseCommandLine(slangCmd);
   ok &= slangDriver.processOptions();
   diag.registerEngine(&slangDriver.sourceManager);

--- a/src/rewrite.cpp
+++ b/src/rewrite.cpp
@@ -294,9 +294,9 @@ void ParameterRewriter::handle(const TypeParameterDeclarationSyntax &pd) {
     auto assignSyn = TypeAssignmentSyntax(decl->name, &newEquals);
     newDeclStrs.emplace_back(assignSyn.toString());
   }
-  auto declStr =
-      fmt::format("{}{}{}", pd.keyword.toString(), pd.typeKeyword.toString(),
-                  fmt::join(newDeclStrs, ", "));
+  auto newDeclStr = fmt::to_string(fmt::join(newDeclStrs, ", "));
+  auto declStr = fmt::format("{}{}{}", pd.keyword.toString(),
+                             pd.typeKeyword.toString(), newDeclStr);
   if (pd.keyword.toString().empty()) {
     diag.log(
         DiagSev::Warning,
@@ -344,8 +344,9 @@ void ParameterRewriter::handle(const ParameterDeclarationSyntax &pd) {
   }
   // Todo: figure out keyword, if the last keyword in the parameter port list
   // was a localparam, it is localparam, otherwise it is parameter
+  auto newDeclStr = fmt::to_string(fmt::join(newDeclStrs, ", "));
   auto declStr = fmt::format("{}{}{}", pd.keyword.toString(),
-                             pd.type->toString(), fmt::join(newDeclStrs, ", "));
+                             pd.type->toString(), newDeclStr);
   if (pd.keyword.toString().empty()) {
     diag.log(
         DiagSev::Warning,


### PR DESCRIPTION
Fixes #22 

- fix dangling reference error (g++-13)
- fix missing `docker-compose` (its now integrated and called `docker compose`)